### PR TITLE
github: Add probot-stale config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,66 @@
+---
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request with the stale
+# label is closed. Set to false to disable. If disabled, issues still need to
+# be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+
+closeComment: >
+  This issue/pull request has been automatically closed due to inactivity and
+  no response to the auto close bot request. If you feel this is
+  inappropriate, please respond to this issue requesting it to be re-opened.
+
+# Limit the number of actions (marking or closing issues/PRs) per hour, from
+# 1-30. Default is 30
+limitPerRun: 30
+
+# Issue specific handling:
+issues:
+  daysUntilStale: 60
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  exemptLabels:
+    - limitation
+    - security
+    - highest-priority
+
+# Pull request specific handling:
+pulls:
+  daysUntilStale: 30
+  markComment: >
+    This pull request has been automatically marked as stale because it has
+    not had recent activity. It will be closed if no further activity occurs.
+    See
+    [assisted pr workflow]
+    (https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md#assisted-pr-workflow)
+    if any developers would like to help pickup this pull request. Thank you
+    for your contributions.
+
+  exemptLabels:
+    - security
+    - release-gating
+    - highest-priority


### PR DESCRIPTION
Add a configuration file for https://github.com/probot/stale that will apply the `stale` label and then close PRs that appear to be abandoned.

This file is a slightly modified version of [1] with the following differences:

- Change `P1` to `highest-priority` to match the new label
  name from the labels database [2].
- Removed the unknown `pinned` label.
- Cleaned up the YAML so it now passes through `yamllint`
  (mostly folding long lines).

[1] - https://github.com/kata-containers/packaging/blob/master/.github/stale.yml
[2] - https://github.com/kata-containers/tests/blob/master/cmd/github-labels/labels.yaml.in

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>