### PR TITLE
stalebot: Warn authors earlier

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,7 +10,7 @@
 # Number of days of inactivity before an Issue or Pull Request with the stale
 # label is closed. Set to false to disable. If disabled, issues still need to
 # be closed manually, but will remain marked as stale.
-daysUntilClose: 7
+daysUntilClose: 22
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false
@@ -38,7 +38,7 @@ limitPerRun: 30
 
 # Issue specific handling:
 issues:
-  daysUntilStale: 60
+  daysUntilStale: 45
   markComment: >
     This issue has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you
@@ -50,7 +50,7 @@ issues:
 
 # Pull request specific handling:
 pulls:
-  daysUntilStale: 30
+  daysUntilStale: 15
   markComment: >
     This pull request has been automatically marked as stale because it has
     not had recent activity. It will be closed if no further activity occurs.


### PR DESCRIPTION
Change the stalebot configuration to give users a warning approximately half way through the time period between the start of inactivity and the time when the issue/PR is closed.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>