### PR TITLE
github: Add kata-collect-data to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,4 +17,6 @@ assignees: ''
 
 # Actual result
 
-(replace this text with details of what actually happened)
+(replace this text with the output of the `kata-collect-data.sh` script, after
+you have reviewed its content to ensure it does not contain any private
+information).


### PR DESCRIPTION
Sync the bug template with the one used in the runtime repo [1] and remove the duplication. Crucially, ask the user to run `kata-collect-data.sh` and paste the results into the bug.

[1] - https://github.com/kata-containers/runtime/blob/master/.github/ISSUE_TEMPLATE.md

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>