### PR TITLE
scripts: kata-hub script should not assume GOPATH is set

### DIFF
--- a/scripts/kata-hub.sh
+++ b/scripts/kata-hub.sh
@@ -277,8 +277,9 @@ find_git_checkout()
     # Check the parent directory first
     dirs+=("$PWD/../${repo_name}")
 
-    # If it's a golang project, it should be here
-    [ -n "$GOPATH" ] && dirs+=("$GOPATH/src/github.com/${repo_slug}")
+    # Check GOPATH in case it's a golang project.
+    [ -z "${GOPATH:-}" ] && GOPATH=$(go env GOPATH 2>/dev/null || true)
+    [ -n "${GOPATH:-}" ] && dirs+=("$GOPATH/src/github.com/${repo_slug}")
 
     local dir
 
@@ -649,8 +650,6 @@ setup()
     do
         command -v "$cmd" &>/dev/null || die "need command: $cmd"
     done
-
-    [ -z "$GOPATH" ] && die "need GOPATH" || true
 }
 
 handle_args()


### PR DESCRIPTION
Fix the handling of GOPATH which may not be set.

Fixes: #11.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>