### PR TITLE
scripts: Make hub-util list-issues-for-pr command reliable

### DIFF
--- a/scripts/hub-util.sh
+++ b/scripts/hub-util.sh
@@ -153,11 +153,12 @@ github_api_url_to_html_url()
 {
         local api_url="${1:-}"
 
-        [ -z "$api_url" ] && die "need API url"
+        [ -z "$api_url" ] && die "need API URL"
 
         echo "$api_url" |\
                 sed \
                 -e 's/api.github.com/github.com/g' \
+                -e 's!/pulls/!/pull/!g' \
                 -e 's!/repos!!g'
 }
 


### PR DESCRIPTION
Fix the `list-issues-for-pr` command to correctly return the list of issues for the specified PR number. The GitHub API appears to be either broken, limited or badly documented. Hence, we are forced to manually extract the issue numbers from the PR.

Also marked the `list-issue-linked-prs` and `list-pr-linked-issues` commands as unreliable, again due to seeming GitHub API limitations.

Fixes: #16.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>