### PR TITLE
scripts: Fix parsing of fixes comments in hub-util script

### DIFF
--- a/scripts/hub-util.sh
+++ b/scripts/hub-util.sh
@@ -766,7 +766,7 @@ list_issues_for_pr()
     #
     local issues=$(echo "$commits" |\
         egrep -v "^( |	)" |\
-        egrep -i "fixes: *(#[0-9][0-9]*)" |\
+        egrep -i "fixes:* *(#[0-9][0-9]*)" |\
         tr ' ' '\n' |\
         grep "[0-9][0-9]*" |\
         sed 's/[.,\#]//g' |\


### PR DESCRIPTION
Correct the parsing logic for the "Fixes" comment in `hub-util.sh` to not require a colon (in other words to accept either "Fixes: #999" or "Fixes #999").

Fixes: #18.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>