### PR TITLE
scripts: Fix label query logic in porting checker script

### DIFF
--- a/scripts/pr-porting-checks.sh
+++ b/scripts/pr-porting-checks.sh
@@ -79,7 +79,7 @@ handle_args()
 	# checks (since the PR is not yet "ready").
 	local ignore_labels=("do-not-merge" "rfc" "wip")
 
-	local labels=$(hub api "/repos/{owner}/{repo}/labels" | jq -r '.[].name')
+	local labels=$(hub issue labels)
 
 	local label
 


### PR DESCRIPTION
Fixed a bug where only the first set of results was being returned when querying repo labels. The fix is either to force pagination, or more simply call `hub(1)` rather than making a raw API call. This change adopts the latter approach.

Fixes: #24.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>