### PR TITLE
github: Improve bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,22 @@ assignees: ''
 
 ---
 
+# Get your issue reviewed faster
+
+To help us understand the problem more quickly, please do the following:
+
+1. Run the `kata-collect-data.sh` script, which is installed as part of Kata Containers.
+   ```sh
+   $ sudo kata-collect-data.sh > /tmp/kata.log
+   ```
+1. Review the output file (`/tmp/kata.log`) to ensure it doesn't
+   contain any private / sensitive information
+1. Paste the *entire* contents of the file into this issue as a comment
+   (the script generates markdown format output).
+
+The information provided will help us to understand the problem more quickly
+so saves time for both of us! :smile:
+
 # Description of problem
 
 (replace this text with the list of steps you followed)
@@ -17,6 +33,8 @@ assignees: ''
 
 # Actual result
 
-(replace this text with the output of the `kata-collect-data.sh` script, after
-you have reviewed its content to ensure it does not contain any private
-information).
+(replace this text with an explanation of what actually happened)
+
+# Further information
+
+(replace this text with any extra information you think might be useful)


### PR DESCRIPTION
Make the `kata-collect-data.sh` part of the template more prominent in the hope that more users will read it and provide the script output.

Fixes: #26.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>