### PR TITLE
scripts: Don't require leading hash for fixes issue number

### DIFF
--- a/scripts/hub-util.sh
+++ b/scripts/hub-util.sh
@@ -755,6 +755,7 @@ list_issues_for_pr()
     # This needs to be careful to take account of lines like this:
     #
     # fixes 99
+    # fixes: 77
     # fixes #123.
     # Fixes: #1, #234, #5678.
     #
@@ -766,7 +767,7 @@ list_issues_for_pr()
     #
     local issues=$(echo "$commits" |\
         egrep -v "^( |	)" |\
-        egrep -i "fixes:* *(#[0-9][0-9]*)" |\
+        egrep -i "fixes:* *(#*[0-9][0-9]*)" |\
         tr ' ' '\n' |\
         grep "[0-9][0-9]*" |\
         sed 's/[.,\#]//g' |\


### PR DESCRIPTION
The "Fixes" comment in a PR is supposed to specify an issue number with a leading `#` (such as `Fixes: #123`). However, we have already merged PR without the `#`. This breaks the hub util scripts `list-issues-for-pr` command, so update that script to accommodate this awkward PRs and allow the related issues to be displayed.

Fixes: #28.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>