### PR TITLE
hub-util: add add-issue-comment command

### DIFF
--- a/scripts/hub-util.sh
+++ b/scripts/hub-util.sh
@@ -599,7 +599,7 @@ move_issue_project_column()
 
     [ "$ret" -eq 0 ] || die "Failed to move issue ${issue} to project $project_type '$project' column '$project_column'"
 
-    echo "Moved issue $issue to column $project_column in project $project_type '$project'"
+    echo "Moved issue $issue to column $project_column in $project_type project '$project'"
 }
 
 list_projects()


### PR DESCRIPTION
Add a new `add-issue-comment` command to allow a comment to be added to an issue.

Fixes: #33.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>