### PR TITLE
docs: Add org README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,56 @@
+<img src="https://www.openstack.org/assets/kata/kata-vertical-on-white.png" width="150">
+
+## Welcome to Kata Containers
+
+Kata Containers is an open source project and community working to build a
+standard implementation of lightweight Virtual Machines (VMs) that feel and
+perform like containers, but provide the workload isolation and security
+advantages of VMs.
+
+## Official website
+
+The main Kata Containers site is https://katacontainers.io.
+
+## Getting started
+
+See the
+[installation documentation](https://github.com/kata-containers/kata-containers/tree/main/docs/install).
+
+## Documentation
+
+See the
+[official documentation](https://github.com/kata-containers/kata-containers/tree/main/docs).
+
+## Developers
+
+The source code and unit test code for Kata Containers lives in the
+[main repository](https://github.com/kata-containers/kata-containers).
+
+## Testers
+
+The
+[`tests`](https://github.com/kata-containers/tests)
+repository contains the more advanced test code run by the
+[Kata Containers Continuous Integration (CI) system](http://jenkins.katacontainers.io/).
+
+The configuration files for the CI itself live in the
+[`ci`](https://github.com/kata-containers/ci) repository.
+
+## Web developers
+
+The source code for the [official website](#official-website) is
+https://github.com/kata-containers/www.katacontainers.io.
+
+## Community
+
+To learn more about the project, its community and governance, see the
+[community repository](https://github.com/kata-containers/community). This is
+the first place to go if you wish to contribute to the project.
+
+## Get help
+
+See the [community](#community) section for ways to contact us.
+
+## Get involved
+
+See the [community](#community) section for ways to join us.


### PR DESCRIPTION
Add an organisation level README to welcome visitors to the project
(rather than just the GitHub default, which shows a bunch of repo links).

Fixes: #38.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>