### PR TITLE
scripts: Fix syntax error

### DIFF
--- a/scripts/pr-porting-checks.sh
+++ b/scripts/pr-porting-checks.sh
@@ -156,7 +156,7 @@ handle_args()
 
 	printf "::debug::PR %s has required porting labels (backport label '%s')\n" \
 		"$pr" \
-		"${backport_labels_found[@]}" \
+		"${backport_labels_found[@]}"
 }
 
 main()


### PR DESCRIPTION
Fix the syntax error introduce inadvertently on #40 which is causing
GitHub Actions using this script to fail.

Fixes: #43.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>