### PR TITLE
templates: Add link to Kata survey

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,3 +44,7 @@ so saves time for both of us! :smile:
 # Further information
 
 (replace this text with any extra information you think might be useful)
+
+# Kata Containers survey
+
+Please consider taking the survey to help us help you: https://openinfrafoundation.formstack.com/forms/kata_containers_user_survey

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -22,3 +22,7 @@ Anything else to add?
 **Before raising this enhancement request**
 
 Have you looked at the [limitations document](https://github.com/kata-containers/kata-containers/blob/main/docs/Limitations.md)?
+
+**Kata Containers survey**
+
+Please consider taking the survey to help us help you: https://openinfrafoundation.formstack.com/forms/kata_containers_user_survey

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -26,3 +26,7 @@ Add any other context or screenshots about the feature request here.
 **Before raising this feature request**
 
 Have you looked at the [limitations document](https://github.com/kata-containers/kata-containers/blob/main/docs/Limitations.md)?
+
+**Kata Containers survey**
+
+Please consider taking the survey to help us help you: https://openinfrafoundation.formstack.com/forms/kata_containers_user_survey

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -10,3 +10,7 @@ assignees: ''
 **Before raising this question**
 
 Have you looked at our [document](https://github.com/kata-containers/kata-containers/tree/main/docs) and still haven't found the answer?
+
+**Kata Containers survey**
+
+Please consider taking the survey to help us help you: https://openinfrafoundation.formstack.com/forms/kata_containers_user_survey


### PR DESCRIPTION
Add a link to the Kata Containers survey in all the templates to try and encourage users to participate.

Fixes: #50.