### PR TITLE
templates: Add notice to repro on latest version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,7 @@ assignees: ''
 
 To help us understand the problem more quickly, please do the following:
 
+1. Ensure that you've reproduced the issue with the [latest release](https://github.com/kata-containers/kata-containers/releases).
 1. Run the `kata-collect-data.sh` script, which is installed as part of Kata Containers
    or `kata-containers.collect-data`, which is installed as part of the Kata Containers
    snapcraft package.


### PR DESCRIPTION
This signals to users that we only support the latest version of Kata.